### PR TITLE
Wrong algorithm for extracting last recurring lineitem from sale

### DIFF
--- a/lib/Twocheckout/Api/TwocheckoutUtil.php
+++ b/lib/Twocheckout/Api/TwocheckoutUtil.php
@@ -39,15 +39,13 @@ class Twocheckout_Util extends Twocheckout
     }
 
     public static function getRecurringLineitems($saleDetail) {
-        $i = 0;
         $invoiceData = array();
 
-        while (isset($saleDetail['sale']['invoices'][$i])) {
-            $invoiceData[$i] = $saleDetail['sale']['invoices'][$i];
-            $i++;
+        foreach ($saleDetail['sale']['invoices'] as $invoice) {
+            $invoiceData[strtotime($invoice['timestamp'])] = $invoice;
         }
 
-        $invoice = max($invoiceData);
+        $invoice = $invoiceData[max(array_keys($invoiceData))];
         $i = 0;
         $lineitemData = array();
 


### PR DESCRIPTION
Not long time ago 2checkout changed invoice_id numeration and biggest invoice_id now doesn't correlate with the latest invoice. I fixed fetching last invoice from sale data. It will be extracted by the last timestamp field value